### PR TITLE
Fix an issue where going "back" to a previous screen showed empty data.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,8 +33,8 @@ android {
     compileSdkVersion 34
 
     defaultConfig {
-        versionCode 1500
-        versionName "1.5.0"
+        versionCode 1501
+        versionName "1.5.1"
         minSdkVersion 14
         targetSdkVersion 34
         namespace "ca.rmen.android.palidamuerte"

--- a/app/src/main/java/ca/rmen/android/palidamuerte/app/category/list/CategoriesFragment.java
+++ b/app/src/main/java/ca/rmen/android/palidamuerte/app/category/list/CategoriesFragment.java
@@ -90,7 +90,7 @@ public class CategoriesFragment extends Fragment { // NO_UCD (unused code)
                     gridView.setAdapter(mAdapter);
                 }
             }
-            mAdapter.changeCursor(new CategoryCursor(cursor));
+            mAdapter.swapCursor(new CategoryCursor(cursor));
             mProgressBar.setVisibility(View.GONE);
         }
 

--- a/app/src/main/java/ca/rmen/android/palidamuerte/app/poem/list/PoemListFragment.java
+++ b/app/src/main/java/ca/rmen/android/palidamuerte/app/poem/list/PoemListFragment.java
@@ -230,7 +230,7 @@ public class PoemListFragment extends ListFragment { // NO_UCD (use default)
                 mAdapter = Poems.getPoemListAdapter(activity, activity.getIntent());
                 setListAdapter(mAdapter);
             }
-            mAdapter.changeCursor(new PoemCursor(cursor));
+            mAdapter.swapCursor(new PoemCursor(cursor));
         }
 
         @Override


### PR DESCRIPTION
Use `swapCursor()` instead of `changeCursor()`

In the documentation for [onLoadFinished](https://developer.android.com/reference/androidx/loader/app/LoaderManager.LoaderCallbacks.html#onLoadFinished(androidx.loader.content.Loader%3CD%3E,D)): 

> The Loader will release the data once it knows the application is no longer using it. For example, if the data is a [android.database.Cursor](https://developer.android.com/reference/android/database/Cursor.html) from a [android.content.CursorLoader](https://developer.android.com/reference/android/content/CursorLoader.html), you should not call close() on it yourself. If the Cursor is being placed in a [android.widget.CursorAdapter](https://developer.android.com/reference/android/widget/CursorAdapter.html), you should use the [**swapCursor**](https://developer.android.com/reference/android/widget/CursorAdapter.html#swapCursor(android.database.Cursor)) method so that the old Cursor is not closed.
